### PR TITLE
Creates notification channel explicitly for Android O

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 
@@ -39,5 +39,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:1.10.19'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 30 19:31:27 IST 2017
+#Thu Apr 26 11:47:45 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -6,8 +6,11 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 
 import static android.app.PendingIntent.FLAG_ONE_SHOT;
 import static android.content.Context.NOTIFICATION_SERVICE;
@@ -39,11 +42,14 @@ public class NotificationService {
     public Notification buildNotification(String title, String message, Intent intent, PendingIntent deleteIntent) {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, message.hashCode(), intent, FLAG_ONE_SHOT);
 
-        int iconResourceId = context.getResources().getIdentifier(
-                "ic_launcher", "mipmap", context.getPackageName());
+        int iconResourceId = android.R.mipmap.sym_def_app_icon;
 
-        if (iconResourceId == 0) {
-            iconResourceId = android.R.mipmap.sym_def_app_icon;
+        try {
+            ApplicationInfo info = context.getPackageManager()
+                    .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            iconResourceId = info.metaData.getInt("com.google.firebase.messaging.default_notification_icon");
+        } catch (Exception e) {
+            Log.i(getClass().getName(), "to customize notifications, please define a default notification in your AndroidManifest.xml");
         }
 
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID)

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -1,10 +1,12 @@
 package com.intentfilter.androidpermissions.services;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 
 import static android.app.PendingIntent.FLAG_ONE_SHOT;
@@ -23,6 +25,15 @@ public class NotificationService {
     private NotificationService(Context context, NotificationManager notificationManager) {
         this.context = context;
         this.notificationManager = notificationManager;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (notificationManager.getNotificationChannel(CHANNEL_ID) == null) {
+                NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                        "Permission request notification channel",
+                        NotificationManager.IMPORTANCE_DEFAULT);
+                notificationManager.createNotificationChannel(channel);
+            }
+        }
     }
 
     public Notification buildNotification(String title, String message, Intent intent, PendingIntent deleteIntent) {

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -39,11 +39,18 @@ public class NotificationService {
     public Notification buildNotification(String title, String message, Intent intent, PendingIntent deleteIntent) {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, message.hashCode(), intent, FLAG_ONE_SHOT);
 
+        int iconResourceId = context.getResources().getIdentifier(
+                "ic_launcher", "mipmap", context.getPackageName());
+
+        if (iconResourceId == 0) {
+            iconResourceId = android.R.mipmap.sym_def_app_icon;
+        }
+
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(message)
                 .setAutoCancel(true)
-                .setSmallIcon(android.R.mipmap.sym_def_app_icon)
+                .setSmallIcon(iconResourceId)
                 .setContentIntent(pendingIntent);
 
         notificationBuilder.setDeleteIntent(deleteIntent);


### PR DESCRIPTION
Android O requires a notification channel to be created in case it doesn't exist. This fix does so.