### PR TITLE
Switch to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
     }
 }
 
@@ -80,7 +80,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.10.0'
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'org.parceler:parceler-api:1.1.12'
     annotationProcessor 'org.parceler:parceler:1.1.12'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 19 22:29:06 IST 2019
+#Sun Oct 27 19:13:18 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionHandler.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionHandler.java
@@ -1,8 +1,8 @@
 package com.intentfilter.androidpermissions;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.intentfilter.androidpermissions.helpers.AppStatus;
 import com.intentfilter.androidpermissions.helpers.Logger;

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionHandler.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionHandler.java
@@ -19,11 +19,11 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 
 class PermissionHandler {
-    private Logger logger;
-    private PermissionManager manager;
+    private final Logger logger;
+    private final PermissionManager manager;
     private final AppStatus appStatus;
-    private HashMap<PermissionManager.PermissionRequestListener, Set<String>> requiredPermissionsMap = new HashMap<>();
-    private Set<String> pendingPermissionRequests = new HashSet<>();
+    private final HashMap<PermissionManager.PermissionRequestListener, Set<String>> requiredPermissionsMap = new HashMap<>();
+    private final Set<String> pendingPermissionRequests = new HashSet<>();
 
     PermissionHandler(PermissionManager manager, Context context) {
         this(new AppStatus(context), Logger.loggerFor(PermissionHandler.class), manager);

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
@@ -31,10 +31,10 @@ import static com.intentfilter.androidpermissions.PermissionsActivity.EXTRA_PERM
 
 public class PermissionManager extends BroadcastReceiver {
 
-    private Context context;
+    private final Context context;
     private final Logger logger;
     private static PermissionManager permissionManager;
-    private PermissionHandler permissionHandler;
+    private final PermissionHandler permissionHandler;
 
     private PermissionManager(Context context) {
         this.context = context;

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
@@ -6,9 +6,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.intentfilter.androidpermissions.helpers.Logger;
 import com.intentfilter.androidpermissions.models.DeniedPermissions;
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static android.app.PendingIntent.FLAG_ONE_SHOT;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static android.support.v4.content.ContextCompat.checkSelfPermission;
+import static androidx.core.content.ContextCompat.checkSelfPermission;
 import static com.intentfilter.androidpermissions.PermissionsActivity.EXTRA_PERMISSIONS;
 import static com.intentfilter.androidpermissions.PermissionsActivity.EXTRA_PERMISSIONS_DENIED;
 import static com.intentfilter.androidpermissions.PermissionsActivity.EXTRA_PERMISSIONS_GRANTED;

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionsActivity.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionsActivity.java
@@ -2,10 +2,10 @@ package com.intentfilter.androidpermissions;
 
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.intentfilter.androidpermissions.helpers.Logger;
 import com.intentfilter.androidpermissions.models.DeniedPermission;

--- a/src/main/java/com/intentfilter/androidpermissions/helpers/AppStatus.java
+++ b/src/main/java/com/intentfilter/androidpermissions/helpers/AppStatus.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class AppStatus {
 
-    private Context context;
+    private final Context context;
 
     public AppStatus(Context context) {
         this.context = context;

--- a/src/main/java/com/intentfilter/androidpermissions/helpers/Logger.java
+++ b/src/main/java/com/intentfilter/androidpermissions/helpers/Logger.java
@@ -5,7 +5,7 @@ import android.util.Log;
 import com.intentfilter.androidpermissions.BuildConfig;
 
 public class Logger {
-    private String LOG_TAG;
+    private final String LOG_TAG;
 
     private Logger(Class clazz) {
         this.LOG_TAG = clazz.getSimpleName();

--- a/src/main/java/com/intentfilter/androidpermissions/models/DeniedPermission.java
+++ b/src/main/java/com/intentfilter/androidpermissions/models/DeniedPermission.java
@@ -1,6 +1,6 @@
 package com.intentfilter.androidpermissions.models;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.parceler.Parcel;
 import org.parceler.ParcelConstructor;

--- a/src/main/java/com/intentfilter/androidpermissions/models/DeniedPermissions.java
+++ b/src/main/java/com/intentfilter/androidpermissions/models/DeniedPermissions.java
@@ -1,7 +1,7 @@
 package com.intentfilter.androidpermissions.models;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import org.parceler.Parcel;
 

--- a/src/main/java/com/intentfilter/androidpermissions/services/BroadcastService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/BroadcastService.java
@@ -2,7 +2,7 @@ package com.intentfilter.androidpermissions.services;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.intentfilter.androidpermissions.models.DeniedPermissions;
 

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -7,7 +7,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 
 import com.intentfilter.androidpermissions.R;
 


### PR DESCRIPTION
Replaces the Support Library with corresponding AndroidX dependencies.

It's important that `implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'` is listed explicitly in `build.gradle`. Android Studio doesn't complain when it's missing, but the code fails at runtime otherwise. `localbroadcastmanager` is not a transitive dependency of `appcompat`, so it seems to be a bug in Android Studio (?).

I also couldn't help myself and marked every field `final` where possible in a separate commit. All tests still run successfully.

Fixes #14.