### PR TITLE
Add ability to set color of the permissions notification

### DIFF
--- a/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
+++ b/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
@@ -1,7 +1,9 @@
 package com.intentfilter.androidpermissions;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
+import androidx.core.app.NotificationCompat;
 
 public class NotificationSettings {
     @StringRes
@@ -10,17 +12,21 @@ public class NotificationSettings {
     private int messageResId;
     @DrawableRes
     private int smallIconResId;
+    @ColorInt
+    private int color;
 
     private NotificationSettings(@StringRes int titleResId, @StringRes int messageResId,
-                                 @DrawableRes int smallIconResId) {
+                                 @DrawableRes int smallIconResId, @ColorInt int color) {
         this.titleResId = titleResId;
         this.messageResId = messageResId;
         this.smallIconResId = smallIconResId;
+        this.color = color;
     }
 
     static NotificationSettings getDefault() {
         return new NotificationSettings(R.string.title_permission_required,
-                R.string.message_permission_required, android.R.mipmap.sym_def_app_icon);
+                R.string.message_permission_required,
+                android.R.mipmap.sym_def_app_icon, NotificationCompat.COLOR_DEFAULT);
     }
 
     @StringRes
@@ -36,6 +42,11 @@ public class NotificationSettings {
     @DrawableRes
     public int getSmallIconResId() {
         return smallIconResId;
+    }
+
+    @ColorInt
+    public int getColor() {
+        return color;
     }
 
     public static class Builder {
@@ -57,6 +68,11 @@ public class NotificationSettings {
 
         public Builder withSmallIcon(@DrawableRes int smallIconResId) {
             this.notificationSettings.smallIconResId = smallIconResId;
+            return this;
+        }
+
+        public Builder withColor(@ColorInt int colorResId) {
+            this.notificationSettings.color = colorResId;
             return this;
         }
 

--- a/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
+++ b/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
@@ -71,8 +71,8 @@ public class NotificationSettings {
             return this;
         }
 
-        public Builder withColor(@ColorInt int colorResId) {
-            this.notificationSettings.color = colorResId;
+        public Builder withColor(@ColorInt int color) {
+            this.notificationSettings.color = color;
             return this;
         }
 

--- a/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
+++ b/src/main/java/com/intentfilter/androidpermissions/NotificationSettings.java
@@ -1,9 +1,8 @@
 package com.intentfilter.androidpermissions;
 
-import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
-import androidx.core.app.NotificationCompat;
 
 public class NotificationSettings {
     @StringRes
@@ -12,21 +11,21 @@ public class NotificationSettings {
     private int messageResId;
     @DrawableRes
     private int smallIconResId;
-    @ColorInt
-    private int color;
+    @ColorRes
+    private int colorResId;
 
     private NotificationSettings(@StringRes int titleResId, @StringRes int messageResId,
-                                 @DrawableRes int smallIconResId, @ColorInt int color) {
+                                 @DrawableRes int smallIconResId, @ColorRes int colorResId) {
         this.titleResId = titleResId;
         this.messageResId = messageResId;
         this.smallIconResId = smallIconResId;
-        this.color = color;
+        this.colorResId = colorResId;
     }
 
     static NotificationSettings getDefault() {
         return new NotificationSettings(R.string.title_permission_required,
                 R.string.message_permission_required,
-                android.R.mipmap.sym_def_app_icon, NotificationCompat.COLOR_DEFAULT);
+                android.R.mipmap.sym_def_app_icon, android.R.color.transparent);
     }
 
     @StringRes
@@ -44,9 +43,9 @@ public class NotificationSettings {
         return smallIconResId;
     }
 
-    @ColorInt
-    public int getColor() {
-        return color;
+    @ColorRes
+    public int getColorResId() {
+        return colorResId;
     }
 
     public static class Builder {
@@ -71,8 +70,8 @@ public class NotificationSettings {
             return this;
         }
 
-        public Builder withColor(@ColorInt int color) {
-            this.notificationSettings.color = color;
+        public Builder withColorResId(@ColorRes int colorResId) {
+            this.notificationSettings.colorResId = colorResId;
             return this;
         }
 

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
@@ -77,10 +77,10 @@ public class PermissionManager extends BroadcastReceiver {
         int titleResId = this.notificationSettings.getTitleResId();
         int messageResId = this.notificationSettings.getMessageResId();
         int smallIconResId = this.notificationSettings.getSmallIconResId();
-        int color = this.notificationSettings.getColor();
+        int colorResId = this.notificationSettings.getColorResId();
 
         Notification notification = notificationService.buildNotification(context.getString(titleResId),
-                context.getString(messageResId), smallIconResId, color, permissionActivityIntent(permissions),
+                context.getString(messageResId), smallIconResId, colorResId, permissionActivityIntent(permissions),
                 notificationDismissIntent(permissions));
         notificationService.notify(permissions.toString(), permissions.hashCode(), notification);
     }

--- a/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
+++ b/src/main/java/com/intentfilter/androidpermissions/PermissionManager.java
@@ -77,9 +77,10 @@ public class PermissionManager extends BroadcastReceiver {
         int titleResId = this.notificationSettings.getTitleResId();
         int messageResId = this.notificationSettings.getMessageResId();
         int smallIconResId = this.notificationSettings.getSmallIconResId();
+        int color = this.notificationSettings.getColor();
 
         Notification notification = notificationService.buildNotification(context.getString(titleResId),
-                context.getString(messageResId), smallIconResId, permissionActivityIntent(permissions),
+                context.getString(messageResId), smallIconResId, color, permissionActivityIntent(permissions),
                 notificationDismissIntent(permissions));
         notificationService.notify(permissions.toString(), permissions.hashCode(), notification);
     }

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import com.intentfilter.androidpermissions.R;
 import com.intentfilter.androidpermissions.helpers.VersionOrchestrator;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.core.app.NotificationCompat;
 
@@ -43,7 +44,7 @@ public class NotificationService {
     }
 
     public Notification buildNotification(String title, String message, @DrawableRes int smallIconResId,
-                                          Intent intent, PendingIntent deleteIntent) {
+                                          @ColorInt int color, Intent intent, PendingIntent deleteIntent) {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, message.hashCode(), intent,
                 VersionOrchestrator.getImmutablePendingIntentFlags(FLAG_ONE_SHOT));
 
@@ -53,6 +54,7 @@ public class NotificationService {
                 .setAutoCancel(true)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setSmallIcon(smallIconResId)
+                .setColor(color)
                 .setContentIntent(pendingIntent);
 
         notificationBuilder.setDeleteIntent(deleteIntent);

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -11,7 +11,7 @@ import android.os.Build;
 import com.intentfilter.androidpermissions.R;
 import com.intentfilter.androidpermissions.helpers.VersionOrchestrator;
 
-import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.core.app.NotificationCompat;
 
@@ -44,7 +44,7 @@ public class NotificationService {
     }
 
     public Notification buildNotification(String title, String message, @DrawableRes int smallIconResId,
-                                          @ColorInt int color, Intent intent, PendingIntent deleteIntent) {
+                                          @ColorRes int colorResId, Intent intent, PendingIntent deleteIntent) {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, message.hashCode(), intent,
                 VersionOrchestrator.getImmutablePendingIntentFlags(FLAG_ONE_SHOT));
 
@@ -54,7 +54,7 @@ public class NotificationService {
                 .setAutoCancel(true)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setSmallIcon(smallIconResId)
-                .setColor(color)
+                .setColor(context.getResources().getColor(colorResId))
                 .setContentIntent(pendingIntent);
 
         notificationBuilder.setDeleteIntent(deleteIntent);

--- a/src/test/java/com/intentfilter/androidpermissions/NotificationSettingsTest.java
+++ b/src/test/java/com/intentfilter/androidpermissions/NotificationSettingsTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import android.graphics.Color;
+
 public class NotificationSettingsTest {
     @Test
     public void shouldCreateNotificationSettingsWithProperParams() {
@@ -12,11 +14,13 @@ public class NotificationSettingsTest {
         NotificationSettings settings = builder.withTitle(R.string.notification_channel_name)
                 .withMessage(R.string.message_permission_required)
                 .withSmallIcon(android.R.drawable.ic_dialog_info)
+                .withColor(Color.CYAN)
                 .build();
 
         assertThat(settings.getTitleResId(), is(R.string.notification_channel_name));
         assertThat(settings.getMessageResId(), is(R.string.message_permission_required));
         assertThat(settings.getSmallIconResId(), is(android.R.drawable.ic_dialog_info));
+        assertThat(settings.getColor(), is(Color.CYAN));
     }
 
     @Test
@@ -26,5 +30,6 @@ public class NotificationSettingsTest {
         assertThat(settings.getTitleResId(), is(R.string.title_permission_required));
         assertThat(settings.getMessageResId(), is(R.string.message_permission_required));
         assertThat(settings.getSmallIconResId(), is(android.R.mipmap.sym_def_app_icon));
+        assertThat(settings.getColor(), is(Color.TRANSPARENT));
     }
 }

--- a/src/test/java/com/intentfilter/androidpermissions/NotificationSettingsTest.java
+++ b/src/test/java/com/intentfilter/androidpermissions/NotificationSettingsTest.java
@@ -5,8 +5,6 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import android.graphics.Color;
-
 public class NotificationSettingsTest {
     @Test
     public void shouldCreateNotificationSettingsWithProperParams() {
@@ -14,13 +12,13 @@ public class NotificationSettingsTest {
         NotificationSettings settings = builder.withTitle(R.string.notification_channel_name)
                 .withMessage(R.string.message_permission_required)
                 .withSmallIcon(android.R.drawable.ic_dialog_info)
-                .withColor(Color.CYAN)
+                .withColorResId(android.R.color.holo_blue_bright)
                 .build();
 
         assertThat(settings.getTitleResId(), is(R.string.notification_channel_name));
         assertThat(settings.getMessageResId(), is(R.string.message_permission_required));
         assertThat(settings.getSmallIconResId(), is(android.R.drawable.ic_dialog_info));
-        assertThat(settings.getColor(), is(Color.CYAN));
+        assertThat(settings.getColorResId(), is(android.R.color.holo_blue_bright));
     }
 
     @Test
@@ -30,6 +28,6 @@ public class NotificationSettingsTest {
         assertThat(settings.getTitleResId(), is(R.string.title_permission_required));
         assertThat(settings.getMessageResId(), is(R.string.message_permission_required));
         assertThat(settings.getSmallIconResId(), is(android.R.mipmap.sym_def_app_icon));
-        assertThat(settings.getColor(), is(Color.TRANSPARENT));
+        assertThat(settings.getColorResId(), is(android.R.color.transparent));
     }
 }


### PR DESCRIPTION
Fixes #37 

I manually tested both setting and not setting the color, and ensured that it works as expected. Also added automated tests.